### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/source/services/api/command/template.yml
+++ b/source/services/api/command/template.yml
@@ -8,7 +8,7 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Timeout: 300
             Environment:
                 Variables:

--- a/source/services/api/device/template.yml
+++ b/source/services/api/device/template.yml
@@ -8,7 +8,7 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Timeout: 300
             Environment:
                 Variables:

--- a/source/services/api/event/template.yml
+++ b/source/services/api/event/template.yml
@@ -8,7 +8,7 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Timeout: 300
             Environment:
                 Variables:

--- a/source/services/api/registration/template.yml
+++ b/source/services/api/registration/template.yml
@@ -8,7 +8,7 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Timeout: 300
             Environment:
                 Variables:

--- a/source/services/api/status/template.yml
+++ b/source/services/api/status/template.yml
@@ -8,7 +8,7 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Timeout: 300
             Environment:
                 Variables:

--- a/source/services/command-status/template.yml
+++ b/source/services/command-status/template.yml
@@ -8,7 +8,7 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Timeout: 300
             Environment:
                 Variables:

--- a/source/services/event-proxy/template.yml
+++ b/source/services/event-proxy/template.yml
@@ -8,7 +8,7 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Timeout: 300
             Environment:
                 Variables:

--- a/source/services/notification/template.yml
+++ b/source/services/notification/template.yml
@@ -8,7 +8,7 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
             Handler: index.handler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Timeout: 300
             Environment:
                 Variables:


### PR DESCRIPTION
CloudFormation templates in smart-product-solution have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.