### PR TITLE
Missing file in build-s3-dist.sh

### DIFF
--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -44,8 +44,8 @@ mkdir -p $build_dist_dir
 echo "------------------------------------------------------------------------------"
 echo "[Packing] Templates"
 echo "------------------------------------------------------------------------------"
-echo "cp $template_dir/smart-product-solution.yaml $template_dist_dir/smart-product-solution.template"
-cp $template_dir/smart-product-solution.yaml $template_dist_dir/smart-product-solution.template
+echo "cp $template_dir/smart-product-solution.template $template_dist_dir/smart-product-solution.template"
+cp $template_dir/smart-product-solution.template $template_dist_dir/smart-product-solution.template
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # Mac OS


### PR DESCRIPTION
*Issue #, if available:* #10 

*Description of changes:*
smart-product-solution.yaml does not exist.
Changed the script to reference .template file

After these changes I was able to complete the deployment (but I have not yet used the stack).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
